### PR TITLE
optimization for large json object

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -141,7 +141,7 @@ class Resource {
           bodyInject.push(this.createScriptSrcTag(url));
         });
         if (this.isInjectInlineResouce() && !/window.__INITIAL_STATE__/.test(html)) {
-          bodyInject.unshift(`<script> window.__INITIAL_STATE__= ${serialize(locals.state || locals, { isJSON: true })};</script>`);
+          bodyInject.unshift(`<script> window.__INITIAL_STATE__= JSON.parse('${serialize(locals.state || locals, { isJSON: true })}');</script>`);
         }
       }
       this.injectHead(headInject);


### PR DESCRIPTION
There's a chance that the initial state of the page may contain very large json object. The evaluation of large json object is slow compared to calling `JSON.parse` function.

Pls check [faster-javascript-apps-with-json-parse](https://www.bram.us/2019/11/25/faster-javascript-apps-with-json-parse/)